### PR TITLE
Add credentials: 'include' in Frontend

### DIFF
--- a/flowo-backend/internal/controller/auth_controller.go
+++ b/flowo-backend/internal/controller/auth_controller.go
@@ -392,7 +392,7 @@ func (ac *AuthController) LoginHandler(c *gin.Context) {
 		Success: true,
 		Message: "Login successful",
 		Session: SessionInfo{
-			SessionID: sessionCookie,
+			SessionID: "",
 			ExpiresAt: time.Now().Add(expiresIn).Unix(),
 			CreatedAt: time.Now().Unix(),
 		},

--- a/flowo-frontend/src/app/routes/Login.tsx
+++ b/flowo-frontend/src/app/routes/Login.tsx
@@ -65,6 +65,7 @@ export default function Login() {
           'accept': 'application/json',
           'Content-Type': 'application/json',
         },
+        credentials: 'include', // IMPORTANT: Include cookies
         body: JSON.stringify({
           email: email.trim(),
           password: password.trim()
@@ -75,30 +76,6 @@ export default function Login() {
         // Handle successful login
         const data = await response.json();
         
-        // Extract and store session token from response.session.session_id
-        let sessionToken = null;
-        if (data.session && data.session.session_id) {
-          sessionToken = data.session.session_id;
-        } else if (data.token) {
-          // Fallback to token field if session structure is different
-          sessionToken = data.token;
-        } else if (data.session_id) {
-          // Another possible structure
-          sessionToken = data.session_id;
-        }
-
-        if (sessionToken) {
-          // Store the session token securely using AuthTokenManager
-          localStorage.setItem('flowo_auth_token', sessionToken);
-          
-          // Also store any additional session data if needed
-          if (data.session) {
-            localStorage.setItem('flowo_session_data', JSON.stringify(data.session));
-          }
-        } else {
-          console.warn('No session token found in login response');
-        }
-
         // Store user information if provided
         if (data.user) {
           localStorage.setItem('flowo_user', JSON.stringify(data.user));

--- a/flowo-frontend/src/contexts/AuthContext.tsx
+++ b/flowo-frontend/src/contexts/AuthContext.tsx
@@ -177,6 +177,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           // 'Session-ID': token,
           // 'X-Session-Token': token,
         },
+        credentials: 'include', // IMPORTANT: Include cookies for session management
       });
 
       if (response.status === 200) {
@@ -276,6 +277,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           'accept': 'application/json',
           'Content-Type': 'application/json',
         },
+        credentials: 'include', // IMPORTANT: Include cookies for session management
         body: JSON.stringify({ 
           email: sanitizedEmail,
           password: password.trim()
@@ -463,6 +465,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           'accept': 'application/json',
           'Authorization': token ? `Bearer ${token}` : '',
         },
+        credentials: 'include', // IMPORTANT: Include cookies for session management
       });
 
       if (response.status === 200) {


### PR DESCRIPTION
- Always add credentials: 'include' in register, login, logout calling
- DOMAIN in .env (backend) is domain of Frontend, add it for CORS
- Remove sessionID response from backend, backend can handle login logic, dont need to handle it manually
